### PR TITLE
0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Implementation notes:
 You can try out the example with:
 
 ```bash
-$ cd examples
+$ cd example
 $ npm install .. && npm run example
 ```
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,15 +1,16 @@
 {
     "version": "1.0.0",
-    "summary": "Run Elm applications on Node.js",
-    "repository": "https://github.com/rtfeldman/elm-node-app.git",
-    "license": "BSD3",
+    "summary": "Run Elm applications on web workers",
+    "repository": "https://github.com/rtfeldman/elm-web-workers.git",
+    "license": "BSD-3-Clause",
     "source-directories": [
         "src/elm"
     ],
     "exposed-modules": [],
     "dependencies": {
-        "circuithub/elm-json-extra": "2.2.1 <= v < 3.0.0",
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-community/elm-json-extra": "1.0.0 <= v < 2.0.0",
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -60,6 +60,11 @@ updateSupervisor supervisorMsg model =
                     in
                         ( { model | messagesReceived = newMessagesReceived }, Supervisor.emit (Encode.string output) )
 
+                Ok ( "echoViaWorker", workerId ) ->
+                    ( model
+                    , Supervisor.send workerId (Encode.string ("I have " ++ toString model.workerIds ++ " workers"))
+                    )
+
                 Ok ( "spawn", workerId ) ->
                     ( { model | workerIds = Set.insert workerId model.workerIds }
                     , Supervisor.send workerId (Encode.string workerId)

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -1,4 +1,4 @@
-module Example (..) where
+module Example exposing (..)
 
 import Signal exposing (Signal)
 import Json.Encode as Encode exposing (Value)
@@ -11,74 +11,74 @@ import String
 
 
 type alias WorkerModel =
-  { id : String }
+    { id : String }
 
 
 type alias SupervisorModel =
-  { messagesReceived : List String
-  , workerIds : Set WorkerId
-  }
+    { messagesReceived : List String
+    , workerIds : Set WorkerId
+    }
 
 
 updateWorker : Value -> WorkerModel -> ( WorkerModel, Worker.Cmd )
 updateWorker data model =
-  case Decode.decodeValue Decode.string data of
-    Ok id ->
-      ( { model | id = id }, Worker.send (Encode.string ("Hi, my name is Worker " ++ id ++ "!")) )
+    case Decode.decodeValue Decode.string data of
+        Ok id ->
+            ( { model | id = id }, Worker.send (Encode.string ("Hi, my name is Worker " ++ id ++ "!")) )
 
-    Err err ->
-      ( model, Worker.send (Encode.string ("Error on worker " ++ model.id ++ ": " ++ err)) )
+        Err err ->
+            ( model, Worker.send (Encode.string ("Error on worker " ++ model.id ++ ": " ++ err)) )
 
 
 updateSupervisor : SupervisorMsg -> SupervisorModel -> ( SupervisorModel, Supervisor.Cmd )
 updateSupervisor supervisorMsg model =
-  case supervisorMsg of
-    FromWorker workerId data ->
-      case Decode.decodeValue Decode.string data of
-        Ok str ->
-          ( model, Supervisor.emit (Encode.string ("worker[" ++ workerId ++ "] says: " ++ str)) )
+    case supervisorMsg of
+        FromWorker workerId data ->
+            case Decode.decodeValue Decode.string data of
+                Ok str ->
+                    ( model, Supervisor.emit (Encode.string ("worker[" ++ workerId ++ "] says: " ++ str)) )
 
-        Err err ->
-          ( model, Supervisor.emit (Encode.string ("worker[" ++ workerId ++ "] sent malformed example data!")) )
+                Err err ->
+                    ( model, Supervisor.emit (Encode.string ("worker[" ++ workerId ++ "] sent malformed example data!")) )
 
-    FromOutside data ->
-      case Decode.decodeValue (Decode.object2 (,) ("msgType" := Decode.string) ("data" := Decode.string)) data of
-        Ok ( "echo", msg ) ->
-          let
-            newMessagesReceived =
-              model.messagesReceived ++ [ msg ]
+        FromOutside data ->
+            case Decode.decodeValue (Decode.object2 (,) ("msgType" := Decode.string) ("data" := Decode.string)) data of
+                Ok ( "echo", msg ) ->
+                    let
+                        newMessagesReceived =
+                            model.messagesReceived ++ [ msg ]
 
-            output =
-              "Here are all the messages I've received so far:\n"
-                ++ (String.join "\n" newMessagesReceived)
-          in
-            ( { model | messagesReceived = newMessagesReceived }, Supervisor.emit (Encode.string output) )
+                        output =
+                            "Here are all the messages I've received so far:\n"
+                                ++ (String.join "\n" newMessagesReceived)
+                    in
+                        ( { model | messagesReceived = newMessagesReceived }, Supervisor.emit (Encode.string output) )
 
-        Ok ( "spawn", workerId ) ->
-          ( { model | workerIds = Set.insert workerId model.workerIds }
-          , Supervisor.send workerId (Encode.string workerId)
-          )
+                Ok ( "spawn", workerId ) ->
+                    ( { model | workerIds = Set.insert workerId model.workerIds }
+                    , Supervisor.send workerId (Encode.string workerId)
+                    )
 
-        Ok ( msgType, msg ) ->
-          Debug.crash ("Urecognized msgType: " ++ msgType ++ " with data: " ++ msg)
+                Ok ( msgType, msg ) ->
+                    Debug.crash ("Urecognized msgType: " ++ msgType ++ " with data: " ++ msg)
 
-        Err err ->
-          ( model, Supervisor.emit (Encode.string ("Error decoding message; error was: " ++ err)) )
+                Err err ->
+                    ( model, Supervisor.emit (Encode.string ("Error decoding message; error was: " ++ err)) )
 
 
 port sendMessage : Signal Value
 port sendMessage =
-  Script.start
-    { worker =
-        { update = updateWorker
-        , init = ( (WorkerModel "0"), Worker.none )
+    Script.start
+        { worker =
+            { update = updateWorker
+            , init = ( (WorkerModel "0"), Worker.none )
+            }
+        , supervisor =
+            { update = updateSupervisor
+            , init = ( (SupervisorModel [] Set.empty), Supervisor.none )
+            }
+        , receiveMessage = receiveMessage
         }
-    , supervisor =
-        { update = updateSupervisor
-        , init = ( (SupervisorModel [] Set.empty), Supervisor.none )
-        }
-    , receiveMessage = receiveMessage
-    }
 
 
 port receiveMessage : Signal Value

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -45,7 +45,7 @@ updateSupervisor supervisorMsg model =
                     ( model, Supervisor.emit (Encode.string ("worker[" ++ workerId ++ "] says: " ++ str)) )
 
                 Err err ->
-                    ( model, Supervisor.emit (Encode.string ("worker[" ++ workerId ++ "] sent malformed example data!")) )
+                    ( model, Supervisor.emit (Encode.string ("worker[" ++ workerId ++ "] sent malformed example data:" ++ toString data)) )
 
         FromOutside data ->
             case Decode.decodeValue (Decode.object2 (,) ("msgType" := Decode.string) ("data" := Decode.string)) data of

--- a/example/Example.elm
+++ b/example/Example.elm
@@ -1,4 +1,4 @@
-module Example exposing (..)
+port module Example exposing (..)
 
 -- This is where the magic happens
 
@@ -10,7 +10,6 @@ import Script.Supervisor as Supervisor exposing (WorkerId, SupervisorMsg(..))
 import Script.Worker as Worker
 import String
 import Html
-import Html.App
 
 
 type alias WorkerModel =
@@ -73,9 +72,6 @@ updateSupervisor supervisorMsg model =
                     ( model, Supervisor.emit (Encode.string ("Error decoding message; error was: " ++ err)) )
 
 
-port sendMessage : Value -> Cmd msg
-
-
 main : Program Never
 main =
     Script.program
@@ -90,9 +86,12 @@ main =
             , subscriptions = \_ -> Sub.none
             , view = \_ -> Html.text "Running..."
             }
-        , receive = receiveMessage identity
-        , send = sendMessge
+        , receive = receive identity
+        , send = send
         }
 
 
-port receiveMessage : (Value -> msg) -> Sub msg
+port send : Value -> Cmd msg
+
+
+port receive : (Value -> msg) -> Sub msg

--- a/example/browser.js
+++ b/example/browser.js
@@ -1,0 +1,16 @@
+var supervisor = new Supervisor("Elm.js", "Example");
+
+supervisor.on("emit", function(msg) {
+  console.log("[supervisor]:", msg);
+});
+
+supervisor.on("close", function(msg) {
+  console.log("Closed with message:", msg);
+});
+
+supervisor.start();
+
+supervisor.send({msgType: "echo", data: "Spawning some workers..."});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});

--- a/example/browser.js
+++ b/example/browser.js
@@ -14,3 +14,8 @@ supervisor.send({msgType: "echo", data: "Spawning some workers..."});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "5"});
+
+setInterval(function() {
+  supervisor.send({msgType: "echoViaWorker", data: "5"});
+}, 2000);

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -1,16 +1,16 @@
 {
     "version": "1.0.0",
     "summary": "elm-node-app example",
-    "repository": "https://github.com/rtfeldman/elm-node-app.git",
-    "license": "BSD3",
+    "repository": "https://github.com/rtfeldman/elm-web-workers.git",
+    "license": "BSD-3-Clause",
     "source-directories": [
         ".",
         "../src/elm"
     ],
     "exposed-modules": [],
     "dependencies": {
-        "circuithub/elm-json-extra": "2.2.1 <= v < 3.0.0",
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-community/elm-json-extra": "1.0.0 <= v < 2.0.0",
+        "elm-lang/core": "4.0.0 <= v < 5.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -10,7 +10,8 @@
     "exposed-modules": [],
     "dependencies": {
         "elm-community/elm-json-extra": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/example/example.js
+++ b/example/example.js
@@ -1,10 +1,8 @@
 var Supervisor = require("elm-web-workers");
 var path = require("path");
 var elmPath = path.join(__dirname, "Elm.js");
-var http = require("http");
 
 var supervisor = new Supervisor(elmPath, "Example");
-
 
 supervisor.on("emit", function(msg) {
   console.log("[supervisor]:", msg);
@@ -29,10 +27,5 @@ supervisor.send({msgType: "spawn", data: "" + Math.random()});
 
 
 setInterval(function() {
-  console.log("sending echoViaWorker message to supervisor...")
   supervisor.send({msgType: "echoViaWorker", data: "5"});
-  console.log("sent message to supervisor without crashing")
 }, 2000);
-
-// Spin up a server just to prevent exiting
-http.createServer(function(request, response) { response.end(); }).listen(8090);

--- a/example/example.js
+++ b/example/example.js
@@ -25,6 +25,8 @@ supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
 
+console.log("This is a prompt. Type stuff in and I'll echo it!")
+
 process.stdin.resume();
 process.stdin.setEncoding('utf8');
 

--- a/example/example.js
+++ b/example/example.js
@@ -1,6 +1,7 @@
 var Supervisor = require("elm-web-workers");
 var path = require("path");
 var elmPath = path.join(__dirname, "Elm.js");
+var http = require("http");
 
 var supervisor = new Supervisor(elmPath, "Example");
 
@@ -16,8 +17,8 @@ supervisor.on("close", function(msg) {
 supervisor.start();
 
 supervisor.send({msgType: "echo", data: "Spawning some workers..."});
-supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "5"});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
@@ -28,34 +29,10 @@ supervisor.send({msgType: "spawn", data: "" + Math.random()});
 
 
 setInterval(function() {
+  console.log("sending echoViaWorker message to supervisor...")
   supervisor.send({msgType: "echoViaWorker", data: "5"});
+  console.log("sent message to supervisor without crashing")
 }, 2000);
 
-console.log("This is a prompt. Type stuff in and I'll echo it!")
-
-process.stdin.resume();
-process.stdin.setEncoding('utf8');
-
-var util = require("util");
-
-process.stdin.on("data", function (text) {
-  var val = util.inspect(text);
-
-  supervisor.send({msgType: "echo", data: val});
-  supervisor.send({msgType: "echoViaWorker", data: "5"});
-  supervisor.send({msgType: "spawn", data: "" + Math.random()});
-  supervisor.send({msgType: "spawn", data: "" + Math.random()});
-  supervisor.send({msgType: "spawn", data: "" + Math.random()});
-  supervisor.send({msgType: "spawn", data: "" + Math.random()});
-  supervisor.send({msgType: "spawn", data: "" + Math.random()});
-  supervisor.send({msgType: "spawn", data: "" + Math.random()});
-
-  if (text === "quit\n") {
-    done();
-  }
-});
-
-function done() {
-  process.exit();
-}
-
+// Spin up a server just to prevent exiting
+http.createServer(function(request, response) { response.end(); }).listen(8090);

--- a/example/example.js
+++ b/example/example.js
@@ -2,7 +2,7 @@ var Supervisor = require("elm-web-workers").Supervisor;
 var path = require("path");
 var elmPath = path.join(__dirname, "Elm.js");
 
-var supervisor = new Supervisor(elmPath, "Example", {receiveMessage: null});
+var supervisor = new Supervisor(elmPath, "Example");
 
 
 supervisor.on("emit", function(msg) {

--- a/example/example.js
+++ b/example/example.js
@@ -17,6 +17,7 @@ supervisor.start();
 
 supervisor.send({msgType: "echo", data: "Spawning some workers..."});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "5"});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
@@ -24,6 +25,11 @@ supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "" + Math.random()});
+
+
+setInterval(function() {
+  supervisor.send({msgType: "echoViaWorker", data: "5"});
+}, 2000);
 
 console.log("This is a prompt. Type stuff in and I'll echo it!")
 
@@ -36,6 +42,7 @@ process.stdin.on("data", function (text) {
   var val = util.inspect(text);
 
   supervisor.send({msgType: "echo", data: val});
+  supervisor.send({msgType: "echoViaWorker", data: "5"});
   supervisor.send({msgType: "spawn", data: "" + Math.random()});
   supervisor.send({msgType: "spawn", data: "" + Math.random()});
   supervisor.send({msgType: "spawn", data: "" + Math.random()});

--- a/example/example.js
+++ b/example/example.js
@@ -15,15 +15,16 @@ supervisor.on("close", function(msg) {
 supervisor.start();
 
 supervisor.send({msgType: "echo", data: "Spawning some workers..."});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
+supervisor.send({msgType: "spawn", data: "" + Math.random()});
 supervisor.send({msgType: "spawn", data: "5"});
-supervisor.send({msgType: "spawn", data: "" + Math.random()});
-supervisor.send({msgType: "spawn", data: "" + Math.random()});
-supervisor.send({msgType: "spawn", data: "" + Math.random()});
-supervisor.send({msgType: "spawn", data: "" + Math.random()});
-supervisor.send({msgType: "spawn", data: "" + Math.random()});
-supervisor.send({msgType: "spawn", data: "" + Math.random()});
-supervisor.send({msgType: "spawn", data: "" + Math.random()});
-supervisor.send({msgType: "spawn", data: "" + Math.random()});
 
 
 setInterval(function() {

--- a/example/example.js
+++ b/example/example.js
@@ -36,6 +36,12 @@ process.stdin.on("data", function (text) {
   var val = util.inspect(text);
 
   supervisor.send({msgType: "echo", data: val});
+  supervisor.send({msgType: "spawn", data: "" + Math.random()});
+  supervisor.send({msgType: "spawn", data: "" + Math.random()});
+  supervisor.send({msgType: "spawn", data: "" + Math.random()});
+  supervisor.send({msgType: "spawn", data: "" + Math.random()});
+  supervisor.send({msgType: "spawn", data: "" + Math.random()});
+  supervisor.send({msgType: "spawn", data: "" + Math.random()});
 
   if (text === "quit\n") {
     done();

--- a/example/example.js
+++ b/example/example.js
@@ -1,4 +1,4 @@
-var Supervisor = require("elm-web-workers").Supervisor;
+var Supervisor = require("elm-web-workers");
 var path = require("path");
 var elmPath = path.join(__dirname, "Elm.js");
 

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Elm Web Workers Example</title>
+
+        <script src="Elm.js"></script>
+        <script src="supervisor.js"></script>
+        <script src="browser.js"></script>
+    </head>
+    <body>
+        <p>Running worker stuff...see console for output!</p>
+    </body>
+</html>

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "example.js",
   "scripts": {
-    "example": "elm-make Example.elm --output=Elm.js && echo \"\nmodule.exports = Elm;\" >> Elm.js && node example.js"
+    "example": "elm-make Example.elm --output=Elm.js && node example.js"
   },
   "author": "Richard Feldman<richard.t.feldman@gmail.com>",
   "license": "BSD-3-Clause",

--- a/example/supervisor.js
+++ b/example/supervisor.js
@@ -1,0 +1,1 @@
+/Users/rtfeldman/code/elm-web-workers/src/js/supervisor.js

--- a/example/worker.js
+++ b/example/worker.js
@@ -1,0 +1,1 @@
+/Users/rtfeldman/code/elm-web-workers/src/js/worker.js

--- a/src/elm/Script.elm
+++ b/src/elm/Script.elm
@@ -1,4 +1,4 @@
-module Script (..) where
+module Script exposing (..)
 
 import Signal exposing (Signal)
 import Json.Decode as Decode exposing (Value, Decoder, (:=), decodeValue)
@@ -9,133 +9,133 @@ import Script.Supervisor as Supervisor exposing (WorkerId, SupervisorMsg(..))
 
 
 type alias Distribute workerModel supervisorModel =
-  { worker :
-      { update : Value -> workerModel -> ( workerModel, Worker.Cmd )
-      , init : ( workerModel, Worker.Cmd )
-      }
-  , supervisor :
-      { update : SupervisorMsg -> supervisorModel -> ( supervisorModel, Supervisor.Cmd )
-      , init : ( supervisorModel, Supervisor.Cmd )
-      }
-  , receiveMessage : Signal Value
-  }
+    { worker :
+        { update : Value -> workerModel -> ( workerModel, Worker.Cmd )
+        , init : ( workerModel, Worker.Cmd )
+        }
+    , supervisor :
+        { update : SupervisorMsg -> supervisorModel -> ( supervisorModel, Supervisor.Cmd )
+        , init : ( supervisorModel, Supervisor.Cmd )
+        }
+    , receiveMessage : Signal Value
+    }
 
 
 messageDecoder : Decoder ( Bool, Maybe WorkerId, Value )
 messageDecoder =
-  Decode.object3 (,,) ("forWorker" := Decode.bool) ("workerId" := (Extra.maybeNull Decode.string)) ("data" := Decode.value)
+    Decode.object3 (,,) ("forWorker" := Decode.bool) ("workerId" := (Extra.maybeNull Decode.string)) ("data" := Decode.value)
 
 
 type Role workerModel supervisorModel
-  = Supervisor workerModel supervisorModel
-  | Worker workerModel supervisorModel
-  | Uninitialized
+    = Supervisor workerModel supervisorModel
+    | Worker workerModel supervisorModel
+    | Uninitialized
 
 
 type Cmd
-  = SupervisorCmd Supervisor.Cmd
-  | WorkerCmd Worker.Cmd
-  | None
+    = SupervisorCmd Supervisor.Cmd
+    | WorkerCmd Worker.Cmd
+    | None
 
 
 start : Distribute workerModel supervisorModel -> Signal Value
 start config =
-  let
-    --handleMessage : Value -> ( Role workerModel supervisorModel, Cmd ) -> ( Role workerModel supervisorModel, Cmd )
-    handleMessage msg ( role, _ ) =
-      case ( role, Decode.decodeValue messageDecoder msg ) of
-        ( _, Err err ) ->
-          Debug.crash ("Malformed JSON received: " ++ err)
+    let
+        --handleMessage : Value -> ( Role workerModel supervisorModel, Cmd ) -> ( Role workerModel supervisorModel, Cmd )
+        handleMessage msg ( role, _ ) =
+            case ( role, Decode.decodeValue messageDecoder msg ) of
+                ( _, Err err ) ->
+                    Debug.crash ("Malformed JSON received: " ++ err)
 
-        ( Uninitialized, Ok ( False, _, data ) ) ->
-          let
-            -- We've received a supervisor message; we must be a supervisor!
-            ( model, cmd ) =
-              config.supervisor.init
+                ( Uninitialized, Ok ( False, _, data ) ) ->
+                    let
+                        -- We've received a supervisor message; we must be a supervisor!
+                        ( model, cmd ) =
+                            config.supervisor.init
 
-            ( workerModel, _ ) =
-              config.worker.init
-          in
-            case handleMessage msg ( (Supervisor workerModel model), None ) of
-              ( newRole, SupervisorCmd newCmd ) ->
-                ( newRole, SupervisorCmd (Supervisor.batch [ cmd, newCmd ]) )
+                        ( workerModel, _ ) =
+                            config.worker.init
+                    in
+                        case handleMessage msg ( (Supervisor workerModel model), None ) of
+                            ( newRole, SupervisorCmd newCmd ) ->
+                                ( newRole, SupervisorCmd (Supervisor.batch [ cmd, newCmd ]) )
 
-              ( _, WorkerCmd _ ) ->
-                Debug.crash "On init, received a worker command instead of the expected supervisor command"
+                            ( _, WorkerCmd _ ) ->
+                                Debug.crash "On init, received a worker command instead of the expected supervisor command"
 
-              ( _, None ) ->
-                Debug.crash "On init, received a None command instead of the expected supervisor command"
+                            ( _, None ) ->
+                                Debug.crash "On init, received a None command instead of the expected supervisor command"
 
-        ( Uninitialized, Ok ( True, _, data ) ) ->
-          let
-            -- We've received a worker message; we must be a worker!
-            ( model, cmd ) =
-              config.worker.init
+                ( Uninitialized, Ok ( True, _, data ) ) ->
+                    let
+                        -- We've received a worker message; we must be a worker!
+                        ( model, cmd ) =
+                            config.worker.init
 
-            ( supervisorModel, _ ) =
-              config.supervisor.init
-          in
-            case handleMessage msg ( (Worker model supervisorModel), None ) of
-              ( newRole, WorkerCmd newCmd ) ->
-                ( newRole, WorkerCmd (Worker.batch [ cmd, newCmd ]) )
+                        ( supervisorModel, _ ) =
+                            config.supervisor.init
+                    in
+                        case handleMessage msg ( (Worker model supervisorModel), None ) of
+                            ( newRole, WorkerCmd newCmd ) ->
+                                ( newRole, WorkerCmd (Worker.batch [ cmd, newCmd ]) )
 
-              ( _, SupervisorCmd _ ) ->
-                Debug.crash "On init, received a supervisor command instead of the expected worker command"
+                            ( _, SupervisorCmd _ ) ->
+                                Debug.crash "On init, received a supervisor command instead of the expected worker command"
 
-              ( _, None ) ->
-                Debug.crash "On init, received a None command instead of the expected worker command"
+                            ( _, None ) ->
+                                Debug.crash "On init, received a None command instead of the expected worker command"
 
-        ( Supervisor workerModel model, Ok ( False, maybeWorkerId, data ) ) ->
-          let
-            -- We're a supervisor; process the message accordingly
-            subMsg =
-              case maybeWorkerId of
-                Nothing ->
-                  FromOutside data
+                ( Supervisor workerModel model, Ok ( False, maybeWorkerId, data ) ) ->
+                    let
+                        -- We're a supervisor; process the message accordingly
+                        subMsg =
+                            case maybeWorkerId of
+                                Nothing ->
+                                    FromOutside data
 
-                Just workerId ->
-                  FromWorker workerId data
+                                Just workerId ->
+                                    FromWorker workerId data
 
-            ( newModel, cmd ) =
-              config.supervisor.update subMsg model
-          in
-            ( Supervisor workerModel newModel, SupervisorCmd cmd )
+                        ( newModel, cmd ) =
+                            config.supervisor.update subMsg model
+                    in
+                        ( Supervisor workerModel newModel, SupervisorCmd cmd )
 
-        ( Worker model supervisorModel, Ok ( True, Nothing, data ) ) ->
-          let
-            -- We're a worker; process the message accordingly
-            ( newModel, cmd ) =
-              config.worker.update data model
-          in
-            ( Worker newModel supervisorModel, WorkerCmd cmd )
+                ( Worker model supervisorModel, Ok ( True, Nothing, data ) ) ->
+                    let
+                        -- We're a worker; process the message accordingly
+                        ( newModel, cmd ) =
+                            config.worker.update data model
+                    in
+                        ( Worker newModel supervisorModel, WorkerCmd cmd )
 
-        ( Worker _ _, Ok ( True, Just _, data ) ) ->
-          Debug.crash ("Received workerId message intended for a worker.")
+                ( Worker _ _, Ok ( True, Just _, data ) ) ->
+                    Debug.crash ("Received workerId message intended for a worker.")
 
-        ( Worker _ _, Ok ( False, _, _ ) ) ->
-          Debug.crash ("Received supervisor message while running as worker.")
+                ( Worker _ _, Ok ( False, _, _ ) ) ->
+                    Debug.crash ("Received supervisor message while running as worker.")
 
-        ( Supervisor _ _, Ok ( True, _, _ ) ) ->
-          Debug.crash ("Received worker message while running as supervisor.")
-  in
-    Signal.foldp handleMessage ( Uninitialized, None ) config.receiveMessage
-      |> Signal.filterMap (snd >> cmdToMsg) Encode.null
+                ( Supervisor _ _, Ok ( True, _, _ ) ) ->
+                    Debug.crash ("Received worker message while running as supervisor.")
+    in
+        Signal.foldp handleMessage ( Uninitialized, None ) config.receiveMessage
+            |> Signal.filterMap (snd >> cmdToMsg) Encode.null
 
 
 cmdToMsg : Cmd -> Maybe Value
 cmdToMsg rawCmd =
-  case rawCmd of
-    SupervisorCmd cmd ->
-      cmd
-        |> Supervisor.encodeCmd
-        |> Encode.list
-        |> Just
+    case rawCmd of
+        SupervisorCmd cmd ->
+            cmd
+                |> Supervisor.encodeCmd
+                |> Encode.list
+                |> Just
 
-    WorkerCmd cmd ->
-      cmd
-        |> Worker.encodeCmd
-        |> Encode.list
-        |> Just
+        WorkerCmd cmd ->
+            cmd
+                |> Worker.encodeCmd
+                |> Encode.list
+                |> Just
 
-    None ->
-      Nothing
+        None ->
+            Nothing

--- a/src/elm/Script/Supervisor.elm
+++ b/src/elm/Script/Supervisor.elm
@@ -1,89 +1,89 @@
-module Script.Supervisor (Cmd, terminate, send, emit, batch, none, WorkerId, SupervisorMsg(..), encodeCmd) where
+module Script.Supervisor exposing (Cmd, terminate, send, emit, batch, none, WorkerId, SupervisorMsg(..), encodeCmd)
 
 import Json.Encode as Encode exposing (Value)
 
 
 type alias WorkerId =
-  String
+    String
 
 
 type SupervisorMsg
-  = FromWorker WorkerId Value
-  | FromOutside Value
+    = FromWorker WorkerId Value
+    | FromOutside Value
 
 
 {-| A command the supervisor can run.
 -}
 type Cmd
-  = Terminate
-  | Send WorkerId Value
-  | Emit Value
-  | Batch (List Cmd)
+    = Terminate
+    | Send WorkerId Value
+    | Emit Value
+    | Batch (List Cmd)
 
 
 {-| Serialize a `Cmd` into a list of `Json.Value` instances.
 -}
 encodeCmd : Cmd -> List Value
 encodeCmd cmd =
-  case cmd of
-    Terminate ->
-      -- Sending a null workerId and null data terminates the supervisor.
-      [ Encode.object
-          [ ( "cmd", Encode.string "TERMINATE" )
-          , ( "workerId", Encode.null )
-          , ( "data", Encode.null )
-          ]
-      ]
+    case cmd of
+        Terminate ->
+            -- Sending a null workerId and null data terminates the supervisor.
+            [ Encode.object
+                [ ( "cmd", Encode.string "TERMINATE" )
+                , ( "workerId", Encode.null )
+                , ( "data", Encode.null )
+                ]
+            ]
 
-    Emit data ->
-      -- Sending a null workerId with String data emits it.
-      [ Encode.object
-          [ ( "cmd", Encode.string "EMIT" )
-          , ( "workerId", Encode.null )
-          , ( "data", data )
-          ]
-      ]
+        Emit data ->
+            -- Sending a null workerId with String data emits it.
+            [ Encode.object
+                [ ( "cmd", Encode.string "EMIT" )
+                , ( "workerId", Encode.null )
+                , ( "data", data )
+                ]
+            ]
 
-    Send workerId data ->
-      [ Encode.object
-          [ ( "cmd", Encode.string "SEND_TO_WORKER" )
-          , ( "workerId", Encode.string workerId )
-          , ( "data", data )
-          ]
-      ]
+        Send workerId data ->
+            [ Encode.object
+                [ ( "cmd", Encode.string "SEND_TO_WORKER" )
+                , ( "workerId", Encode.string workerId )
+                , ( "data", data )
+                ]
+            ]
 
-    Batch cmds ->
-      List.concatMap encodeCmd cmds
+        Batch cmds ->
+            List.concatMap encodeCmd cmds
 
 
 {-| Terminate the supervisor and all workers.
 -}
 terminate : Cmd
 terminate =
-  Terminate
+    Terminate
 
 
 {-| Send a `Json.Value` to a particular worker.
 -}
 send : WorkerId -> Value -> Cmd
 send =
-  Send
+    Send
 
 
 {-| Combine several supervisor commands.
 -}
 batch : List Cmd -> Cmd
 batch =
-  Batch
+    Batch
 
 
 emit : Value -> Cmd
 emit =
-  Emit
+    Emit
 
 
 {-| Do nothing.
 -}
 none : Cmd
 none =
-  batch []
+    batch []

--- a/src/elm/Script/Worker.elm
+++ b/src/elm/Script/Worker.elm
@@ -1,4 +1,4 @@
-module Script.Worker (Cmd, send, batch, none, encodeCmd) where
+module Script.Worker exposing (Cmd, send, batch, none, encodeCmd)
 
 import Json.Encode as Encode exposing (Value)
 
@@ -6,38 +6,38 @@ import Json.Encode as Encode exposing (Value)
 {-| A command the worker can run.
 -}
 type Cmd
-  = Send Value
-  | Batch (List Cmd)
+    = Send Value
+    | Batch (List Cmd)
 
 
 {-| Serialize a `Cmd` into a list of `Json.Value` instances.
 -}
 encodeCmd : Cmd -> List Value
 encodeCmd cmd =
-  case cmd of
-    Send data ->
-      [ data ]
+    case cmd of
+        Send data ->
+            [ data ]
 
-    Batch cmds ->
-      List.concatMap encodeCmd cmds
+        Batch cmds ->
+            List.concatMap encodeCmd cmds
 
 
 {-| Send a `Json.Value` to the supervisor.
 -}
 send : Value -> Cmd
 send =
-  Send
+    Send
 
 
 {-| Combine several worker commands.
 -}
 batch : List Cmd -> Cmd
 batch =
-  Batch
+    Batch
 
 
 {-| Do nothing.
 -}
 none : Cmd
 none =
-  batch []
+    batch []

--- a/src/js/supervisor.js
+++ b/src/js/supervisor.js
@@ -5,22 +5,24 @@ function Supervisor(elmPath, elmModuleName, args, sendMessagePortName, receiveMe
     workerPath = (require && require.resolve) ? require.resolve("./worker.js") : "worker.js";
   }
 
-  if (typeof args === "undefined") {
-    args = {};
-  }
-
   var Elm = typeof Elm === "undefined" ? require(elmPath) : Elm;
 
-  var elmApp = Elm.worker(Elm[elmModuleName], args);
+  var elmApp =
+      Elm[elmModuleName].worker()
+
+  // var elmApp =
+  //   typeof args === "undefined"
+  //     ? Elm[elmModuleName].worker()
+  //     : Elm[elmModuleName].worker(args);
 
   if (typeof sendMessagePortName === "undefined") {
-    sendMessagePortName = "sendMessage";
+    sendMessagePortName = "send";
   } else if (typeof sendMessagePortName !== "string") {
     throw new Error("Invalid sendMessagePortName: " + sendMessagePortName);
   }
 
   if (typeof receiveMessagePortName === "undefined") {
-    receiveMessagePortName = "receiveMessage";
+    receiveMessagePortName = "receive";
   } else if (typeof receiveMessagePortName !== "string") {
     throw new Error("Invalid receiveMessagePortName: " + receiveMessagePortName);
   }

--- a/src/js/supervisor.js
+++ b/src/js/supervisor.js
@@ -163,11 +163,9 @@ function supervise(subscribe, send, emit, workerPath, workerConfig) {
                   if (typeof contents === "undefined") {
                     return console.error("Received `undefined` as a message from worker[" + workerId + "]");
                   } else {
-                    contents.forEach(function(content) {
-                      // When the worker sends a message, tag it with this workerId
-                      // and then send it along for the supervisor to handle.
-                      return send({forWorker: false, workerId: workerId, data: content});
-                    });
+                    // When the worker sends a message, tag it with this workerId
+                    // and then send it along for the supervisor to handle.
+                    return send({forWorker: false, workerId: workerId, data: contents});
                   }
 
                 default:

--- a/src/js/supervisor.js
+++ b/src/js/supervisor.js
@@ -152,25 +152,11 @@ function supervise(subscribe, send, emit, workerPath, workerConfig) {
             }
 
             worker.onmessage = function(event) {
-              var data = event.data || {};
-              var contents = data.contents;
-
-              switch (data.cmd) {
-                case "WORKER_ERROR":
-                  return console.error("Error in worker[" + workerId + "]: " + contents);
-
-                case "MESSAGE_FROM_WORKER":
-                  if (typeof contents === "undefined") {
-                    return console.error("Received `undefined` as a message from worker[" + workerId + "]");
-                  } else {
-                    // When the worker sends a message, tag it with this workerId
-                    // and then send it along for the supervisor to handle.
-                    return send({forWorker: false, workerId: workerId, data: contents});
-                  }
-
-                default:
-                  throw new Error("Received unrecognized msgType from worker[" + workerId + "]: " + contents);
-              }
+              (event.data || []).forEach(function(contents) {
+                // When the worker sends a message, tag it with this workerId
+                // and then send it along for the supervisor to handle.
+                return send({forWorker: false, workerId: workerId, data: contents});
+              });
             };
 
             // Record this new worker in the lookup table.

--- a/src/js/supervisor.js
+++ b/src/js/supervisor.js
@@ -178,11 +178,13 @@ function supervise(subscribe, send, emit, workerPath, workerConfig) {
             // Record this new worker in the lookup table.
             workers[workerId] = worker;
 
-            worker.postMessage({cmd: "INIT_WORKER", data: workerConfig});
-
             // Give the worker a tick to initialize before posting the message.
             return setTimeout(function() {
-              worker.postMessage(message);
+              worker.postMessage({cmd: "INIT_WORKER", data: workerConfig});
+
+              return setTimeout(function() {
+                worker.postMessage(message);
+              });
             }, 0);
           }
         }

--- a/src/js/supervisor.js
+++ b/src/js/supervisor.js
@@ -156,7 +156,6 @@ function supervise(subscribe, send, emit, workerPath, workerConfig) {
             function handleWorkerMessage(event) {
               switch (event.data.type) {
                 case "initialized":
-                  console.log("WORKER " + workerId + " initialized");
                   worker.postMessage(message);
 
                   break;

--- a/src/js/supervisor.js
+++ b/src/js/supervisor.js
@@ -7,13 +7,7 @@ function Supervisor(elmPath, elmModuleName, args, sendMessagePortName, receiveMe
 
   var Elm = typeof Elm === "undefined" ? require(elmPath) : Elm;
 
-  var elmApp =
-    Elm[elmModuleName].worker()
-
-  // var elmApp =
-  //   typeof args === "undefined"
-  //     ? Elm[elmModuleName].worker()
-  //     : Elm[elmModuleName].worker(args);
+  var elmApp = Elm[elmModuleName].worker(args);
 
   if (typeof sendMessagePortName === "undefined") {
     sendMessagePortName = "send";

--- a/src/js/supervisor.js
+++ b/src/js/supervisor.js
@@ -2,10 +2,10 @@ var Worker = typeof Worker === "undefined" ? require("webworker-threads").Worker
 
 function Supervisor(elmPath, elmModuleName, args, sendMessagePortName, receiveMessagePortName, workerPath) {
   if (typeof workerPath === "undefined") {
-    workerPath = (require && require.resolve) ? require.resolve("./worker.js") : "worker.js";
+    workerPath = (typeof require !== "undefined" && require.resolve) ? require.resolve("./worker.js") : "worker.js";
   }
 
-  var Elm = typeof Elm === "undefined" ? require(elmPath) : Elm;
+  Elm = typeof Elm === "undefined" ? require(elmPath) : Elm;
 
   var elmApp = Elm[elmModuleName].worker(args);
 

--- a/src/js/supervisor.js
+++ b/src/js/supervisor.js
@@ -147,13 +147,17 @@ function supervise(subscribe, send, emit, workerPath, workerConfig) {
             // This workerId is unknown to us; init a new worker before sending.
             var worker = new Worker(workerPath);
 
+            worker.onerror = function(err) {
+              console.error("Exception in worker[" + workerId + "]: " + JSON.stringify(err));
+            }
+
             worker.onmessage = function(event) {
               var data = event.data || {};
               var contents = data.contents;
 
               switch (data.cmd) {
                 case "WORKER_ERROR":
-                  return console.error("Exception in worker[" + workerId + "]: " + contents);
+                  return console.error("Error in worker[" + workerId + "]: " + contents);
 
                 case "MESSAGE_FROM_WORKER":
                   if (typeof contents === "undefined") {

--- a/src/js/supervisor.js
+++ b/src/js/supervisor.js
@@ -198,4 +198,6 @@ function supervise(subscribe, send, emit, workerPath, workerConfig) {
   });
 }
 
-module.exports.Supervisor = Supervisor;
+if (typeof module === "object") {
+  module.exports = Supervisor;
+}

--- a/src/js/supervisor.js
+++ b/src/js/supervisor.js
@@ -160,16 +160,6 @@ function supervise(subscribe, send, emit, workerPath, workerConfig) {
 
                   break;
 
-                case "setTimeout":
-                  var delay = event.data.delay;
-                  var id = event.data.id;
-
-                  setTimeout(function() {
-                    worker.postMessage({cmd: "RUN_SET_TIMEOUT_CALLBACK", data: id});
-                  }, delay);
-
-                  break;
-
                 case "messages":
                   (event.data.contents || []).forEach(function(contents) {
                     // When the worker sends a message, tag it with this workerId

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -9,8 +9,10 @@ function sendError(err) {
   self.postMessage({cmd: "WORKER_ERROR", contents: err});
 }
 
-function sendMessage(message) {
-  self.postMessage({cmd: "MESSAGE_FROM_WORKER", contents: message});
+function sendMessages(messages) {
+  messages.forEach(function(msg) {
+    self.postMessage({cmd: "MESSAGE_FROM_WORKER", contents: msg});
+  });
 }
 
 self.onmessage = function(event) {
@@ -30,7 +32,7 @@ self.onmessage = function(event) {
 
           elmApp = Elm[config.elmModuleName].worker(config.args);
 
-          elmApp.ports[config.sendMessagePortName].subscribe(sendMessage);
+          elmApp.ports[config.sendMessagePortName].subscribe(sendMessages);
         } catch(err) {
           sendError("Error initializing Elm in worker: " + err);
         }

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -1,6 +1,5 @@
 var Elm;
 var elmApp;
-var sendMessagePortName;
 var receiveMessagePortName;
 
 module = typeof module === "undefined" ? {} : module;

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -1,19 +1,27 @@
-console.log("I AM A WORKER");
+// self.postMessage("I'm still working before postMessage('ali').");
+
+// self.onmessage = function(event) {
+  // postMessage('Hi ' + event.data);
+  // self.close();
+// };
+
 
 var receiveMessagePortName;
-
-module = typeof module === "undefined" ? {} : module;
-setTimeout = typeof setTimeout === "undefined" ? function(callback) { return callback() } : setTimeout;
-
-function sendMessage(message) {
-  console.log("POSTM")
-  self.postMessage(message);
-}
 
 self.onmessage = function(event) {
   var msg = event.data;
 
   switch (msg.cmd) {
+    case "RUN_SET_TIMEOUT_CALLBACK":
+      var id = msg.data;
+      var callback = setTimeouts[id];
+
+      setTimeouts[id] = undefined;
+
+      callback();
+
+      break;
+
     case "INIT_WORKER":
       if (typeof elmApp === "undefined") {
         var config = JSON.parse(msg.data);
@@ -26,10 +34,13 @@ self.onmessage = function(event) {
 
           receiveMessagePortName = config.receiveMessagePortName;
 
-
           elmApp = Elm[config.elmModuleName].worker(config.args);
 
-          elmApp.ports[config.sendMessagePortName].subscribe(sendMessage);
+          elmApp.ports[config.sendMessagePortName].subscribe(sendMessages);
+
+          // Tell the supervisor we're initialized, so it can run the
+          // pending message that was waiting for init to complete.
+          self.postMessage({type: "initialized"});
         } catch(err) {
           throw new Error("Error initializing Elm in worker: " + err);
         }
@@ -55,4 +66,35 @@ self.onmessage = function(event) {
     default:
       throw new Error("Unrecognized worker command: " + msg.cmd);
   }
+
+  // This is mandatory somehow. #WTF
+  // self.close();
 };
+
+// This is a hack to implement setTimeout on a worker by telling the supervisor
+// we want a setTimeout to happen, then having the supervisor report back when
+// we should run the callback. This is necessary because the generated Elm code
+// relies on setTimeout functioning properly in order to yield in between work
+// queue operations. If you instead polyfill setTimeout using something like
+// function(callback) { return callback(); }, the behavior you get is that
+// spawnLoop never yields, and thus never terminates, and the worker gets stuck.
+var setTimeouts = {};
+var setTimeoutId = 0;
+
+if (typeof setTimeout === "undefined") {
+  setTimeout = function setTimeout(callback, delay) {
+    setTimeoutId++;
+    setTimeouts[setTimeoutId] = callback;
+
+    self.postMessage({type: "setTimeout", delay: delay, id: setTimeoutId});
+  }
+}
+
+if (typeof module === "undefined") {
+  module = {};
+}
+
+
+function sendMessages(messages) {
+  self.postMessage({type: "messages", contents: messages});
+}

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -1,10 +1,10 @@
-// self.postMessage("I'm still working before postMessage('ali').");
-
-// self.onmessage = function(event) {
-  // postMessage('Hi ' + event.data);
-  // self.close();
-// };
-
+// TODO: this still doesn't quite work right. Messages are getting dropped.
+// In a browser, things work great.
+// In here, not so much. Not all the threads report that they initialized
+// successfully, and then even fewer greet successfully.
+// onerror doesn't work, so we need to wrap everything in a try/catch
+// and send a {type: error} message to the parent if something blows up.
+// At least that will get us some visibility.
 
 var receiveMessagePortName;
 

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -19,11 +19,13 @@ self.onmessage = function(event) {
         var config = JSON.parse(msg.data);
 
         try {
+          module = {};
+
           importScripts(config.elmPath);
+          var Elm = module.exports;
 
           receiveMessagePortName = config.receiveMessagePortName;
 
-          Elm = typeof Elm === "undefined" ? module.exports : Elm;
 
           elmApp = Elm[config.elmModuleName].worker(config.args);
 

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -28,13 +28,7 @@ self.onmessage = function(event) {
 
           Elm = typeof Elm === "undefined" ? module.exports : Elm;
 
-          elmApp =
-              Elm[config.elmModuleName].worker()
-
-          // elmApp =
-          //   typeof config.args === "undefined"
-          //     ? Elm[config.elmModuleName].worker()
-          //     : Elm[config.elmModuleName].worker(config.args);
+          elmApp = Elm[config.elmModuleName].worker(config.args);
 
           elmApp.ports[config.sendMessagePortName].subscribe(sendMessage);
         } catch(err) {

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -12,16 +12,6 @@ self.onmessage = function(event) {
   var msg = event.data;
 
   switch (msg.cmd) {
-    case "RUN_SET_TIMEOUT_CALLBACK":
-      var id = msg.data;
-      var callback = setTimeouts[id];
-
-      setTimeouts[id] = undefined;
-
-      callback();
-
-      break;
-
     case "INIT_WORKER":
       if (typeof elmApp === "undefined") {
         var config = JSON.parse(msg.data);

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -1,9 +1,10 @@
-var module = typeof module === "undefined" ? {} : module;
-var setTimeout = typeof setTimeout === "undefined" ? function(callback) { return callback() } : setTimeout;
 var Elm;
 var elmApp;
 var sendMessagePortName;
 var receiveMessagePortName;
+
+module = typeof module === "undefined" ? {} : module;
+setTimeout = typeof setTimeout === "undefined" ? function(callback) { return callback() } : setTimeout;
 
 function sendError(err) {
   self.postMessage({cmd: "WORKER_ERROR", contents: err});

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -5,18 +5,14 @@ var receiveMessagePortName;
 module = typeof module === "undefined" ? {} : module;
 setTimeout = typeof setTimeout === "undefined" ? function(callback) { return callback() } : setTimeout;
 
-function sendError(err) {
-  self.postMessage({cmd: "WORKER_ERROR", contents: err});
-}
-
-function sendMessages(messages) {
-  messages.forEach(function(msg) {
-    self.postMessage({cmd: "MESSAGE_FROM_WORKER", contents: msg});
-  });
+function sendMessage(message) {
+  console.log("POSTM")
+  self.postMessage(message);
 }
 
 self.onmessage = function(event) {
   var msg = event.data;
+  console.log("worker got a msg");
 
   switch (msg.cmd) {
     case "INIT_WORKER":

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -12,7 +12,6 @@ function sendMessage(message) {
 
 self.onmessage = function(event) {
   var msg = event.data;
-  console.log("worker got a msg");
 
   switch (msg.cmd) {
     case "INIT_WORKER":
@@ -28,30 +27,30 @@ self.onmessage = function(event) {
 
           elmApp = Elm[config.elmModuleName].worker(config.args);
 
-          elmApp.ports[config.sendMessagePortName].subscribe(sendMessages);
+          elmApp.ports[config.sendMessagePortName].subscribe(sendMessage);
         } catch(err) {
-          sendError("Error initializing Elm in worker: " + err);
+          throw new Error("Error initializing Elm in worker: " + err);
         }
       } else {
-        sendError("Worker attempted to initialize twice!");
+        throw new Error("Worker attempted to initialize twice!");
       }
 
       break;
 
     case "SEND_TO_WORKER":
       if (typeof elmApp === "undefined") {
-        sendError("Canot send() to a worker that has not yet been initialized!");
+        throw new Error("Canot send() to a worker that has not yet been initialized!");
       }
 
       try {
         elmApp.ports[receiveMessagePortName].send({forWorker: true, workerId: null, data: msg.data});
       } catch (err) {
-        sendError("Error attempting to send message to Elm Worker: " + err);
+        throw new Error("Error attempting to send message to Elm Worker: " + err);
       }
 
       break;
 
     default:
-      sendError("Unrecognized worker command: " + msg.cmd);
+      throw new Error("Unrecognized worker command: " + msg.cmd);
   }
 };

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -60,6 +60,9 @@ self.onmessage = function(event) {
 
 // Polyfill setTimeout
 if (typeof setTimeout === "undefined") {
+  // TODO verify that this actually works with values other than 0. It has never
+  // been verified as of the writing of this comment, but should be before
+  // someone uses `sleep` and is surprised when it (maybe) doesn't work.
   function delayUntil(time, callback) {
     if (new Date().getTime() >= time) {
       callback();

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -1,5 +1,5 @@
-var Elm;
-var elmApp;
+console.log("I AM A WORKER");
+
 var receiveMessagePortName;
 
 module = typeof module === "undefined" ? {} : module;

--- a/src/js/worker.js
+++ b/src/js/worker.js
@@ -23,8 +23,14 @@ self.onmessage = function(event) {
           try {
             importScripts(config.elmPath);
 
-            Elm = typeof Elm === "undefined" ? module.exports : Elm;
-            elmApp = Elm.worker(Elm[config.elmModuleName], config.args);
+            elmApp =
+                Elm[config.elmModuleName].worker()
+
+            // elmApp =
+            //   typeof config.args === "undefined"
+            //     ? Elm[config.elmModuleName].worker()
+            //     : Elm[config.elmModuleName].worker(config.args);
+
           } catch(err) {
             sendError("Error initializing Elm in worker: " + err);
           }


### PR DESCRIPTION
**EDIT**: fixed and merged! See comment below.

So far this is close to working in 0.17, but not quite. I'm gonna take a bunch of notes here for when I come back to this.

Everything compiles, the supervisor works fine, and the workers can send messages to the supervisor.

On the worker, instantiating an Elm worker works. You can `send` to its port, and doing so does not throw an exception.

However, the outgoing port on the `Elm` instance on the worker thread never sends anything out. No matter what happens, that thing just stays totally quiet. I can't even get it to send a message out on `init`.

I've spent about 3 hours trying to get it to communicate and am giving up for now. Notes:
- Web worker threads have different globals. I'm stubbing `setTimeout` to be a pass-through, so that might be causing problems. I don't think that's what it is, since they're all calls to `setTimeout 0`, but it's possible.
- @evancz suggested I edit the raw `Elm.js` to investigate what's going on. I got it working in the browser, but I don't know the generated code well enough to do anything useful yet.
- If I add `sendError("init worker");` right after `case "INIT_WORKER":` it works in the browser, but not on Node...but then if I add `sendError("send to worker");` right after `case "SEND_TO_WORKER":` they both show up.
- At one point in the browser I actually saw the "Hi, I'm a worker" message - but then I couldn't reproduce after refreshing. No idea what to make of that.
## Running it in the browser

This works except that `init` is ignored for some reason.

Theoretically `require` stuff like browserify/webpack should work, but I haven't tried it that way yet.

What I did instead:

```
cd example
ln -s /Users/rtfeldman/code/elm-web-workers/src/js/supervisor.js /Users/rtfeldman/code/elm-web-workers/example/supervisor.js
ln -s /Users/rtfeldman/code/elm-web-workers/src/js/worker.js /Users/rtfeldman/code/elm-web-workers/example/worker.js
http-server .
```

A useful trick to add to the generated Elm.js:

``` js
    if (typeof window === "undefined") {
      console.log("hi from workertown!")
      self.postMessage({cmd: "WORKER_ERROR", contents: "sending some work, yo"});
    }
```
## Running it in Node

See the README for how to run the example.

I've narrowed down the problematic behavior on Node to the port on the Worker never receiving anything. It spins up - the file gets loaded (confirmed via Debug.log), and its initial view function gets called (also confirmed via Debug.log), but its subscriptions don't work. It never receives anything from the port...on Node. In the browser it works fine.

In worker.js:

``` js
        elmApp.ports[receiveMessagePortName].send({forWorker: true, workerId: null, data: msg.data});
        console.log("just sent to worker port: ", JSON.stringify({forWorker: true, workerId: null, data: msg.data}))
```

In Example.elm:

``` elm
        , receive = receive (Debug.log "JUST RECEIVED")
```

If I do this, I get `JUST RECEIVED` printed out for the supervisor (with messages that have `forWorker: false`), but not for the worker, even after seeing the `forWorker: true` logged successfully above.

I actually never see `forWorker = True` come through that `Debug.log` on Node - not even once. In the browser I see plenty of them.
